### PR TITLE
Support `usp=share_link` by not validating query parameter at all

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 const formatRegexes = new Set([
-	/https:\/\/drive\.google\.com\/file\/d\/(?<id>.*?)\/(?:edit|view)\?usp=sharing/,
+	/https:\/\/drive\.google\.com\/file\/d\/(?<id>.*?)\/(?:edit|view)/,
 	/https:\/\/drive\.google\.com\/open\?id=(?<id>.*?)$/,
 ]);
 

--- a/test.js
+++ b/test.js
@@ -10,6 +10,12 @@ test('main', t => {
 	);
 	t.is(
 		driveUrl(
+			'https://drive.google.com/file/d/1Px8bePd7pFSz5r6bTA7GKN9HloCzMfFk/view?usp=share_link',
+		),
+		'https://drive.google.com/uc?export=download&id=1Px8bePd7pFSz5r6bTA7GKN9HloCzMfFk',
+	);
+	t.is(
+		driveUrl(
 			'https://drive.google.com/file/d/1Px8bePd7pFSz5r6bTA7GKN9HloCzMfFk/view?usp=sharing',
 			{apiKey: 'foo'},
 		),


### PR DESCRIPTION
When you generate a public share link via the "**Share**" option creates a different link than when you generate it using the "**Get Link**" option.

![image](https://user-images.githubusercontent.com/9216496/217072229-ca1d38c4-c1c4-49c1-b909-27988fffba69.png)


**Share** generates a link ending in `?usp=sharing` while **Get Link** generates a link ending in `?usp=share_link`.

Omitting the `?usp=...` still counts as a valid link, and the id can still be extracted from the link.